### PR TITLE
Skip first data column during CSV import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+__pycache__/

--- a/XrommBlenderToolkit_scripts/xrommUI.py
+++ b/XrommBlenderToolkit_scripts/xrommUI.py
@@ -98,6 +98,14 @@ bpy.types.Scene.importfile = bpy.props.StringProperty(
     subtype='FILE_PATH'
 )
 
+# Boolean property for skipping the first data column
+bpy.types.Scene.skipFirstColumn = bpy.props.BoolProperty(
+    name="Skip first data column",
+    description="Skip the first data column during CSV import (e.g., if they include the frame number)",
+    default=False
+)
+
+
 # Define a boolean property for the checkboxes
 bpy.types.Scene.isTranslationImp = bpy.props.BoolProperty(
     name="import Translations",
@@ -119,16 +127,16 @@ bpy.types.Scene.new_or_selected = bpy.props.EnumProperty (
     default='NEW'
 )
 
-# Define an operator for creating an xCam
+# Define an operator for importing Rigid body transformations
 class ImportOperator(bpy.types.Operator):
     bl_idname = "scene.importfile"
-    bl_label = "Import Rigid Body Data to selected object"
-    bl_description = "Import data"
+    bl_description = "Import Rigid Body Data to selected object"
+    bl_label = "Import data"
 
     def execute(self, context):
         ###########################################################
         from . import xrommimport
-        xrommimport.importRBT(context.scene.importfile)
+        xrommimport.importRBT(context.scene.importfile, context.scene.skipFirstColumn) #pass the CSV file path, and the boolean that decides whether the first column is skipped
         ###########################################################
         self.report({'INFO'}, "importing csv")
         return {'FINISHED'}
@@ -161,6 +169,7 @@ class ImportPanel(bpy.types.Panel):
         scene = context.scene
 
         layout.prop(scene, "importfile", text="CSV")
+        layout.prop(scene, "skipFirstColumn")
         layout.separator()
         layout.label(text="Import Rigid Body transformations:")
         layout.operator("scene.importfile")

--- a/XrommBlenderToolkit_scripts/xrommUI.py
+++ b/XrommBlenderToolkit_scripts/xrommUI.py
@@ -132,6 +132,7 @@ class ImportOperator(bpy.types.Operator):
     bl_idname = "scene.importfile"
     bl_description = "Import Rigid Body Data to selected object"
     bl_label = "Import data"
+    bl_options = {"UNDO"} #enable undoing
 
     def execute(self, context):
         ###########################################################
@@ -146,7 +147,8 @@ class ImportTransRotOperator(bpy.types.Operator):
     bl_idname = "scene.importtrfile"
     bl_label = "Import translation/rotation data"
     bl_description = "Import translation and/or rotation data to selected object or new sphere(s)"
-
+    bl_options = {"UNDO"} #enable undoing
+    
     def execute(self, context):
         ###########################################################
         from . import transrotimport

--- a/XrommBlenderToolkit_scripts/xrommimport.py
+++ b/XrommBlenderToolkit_scripts/xrommimport.py
@@ -57,6 +57,9 @@ def importRBT(importCSV, skipFirstColumn):
     # Set the current frame to 1
     bpy.context.scene.frame_set(1)
 
+    # Set the playback in the scene to end with the final frame of the imported data
+
+    bpy.data.scenes[0].frame_end = len(transformations)
 
 
     # Loop through each transformation and create a keyframe for each frame

--- a/XrommBlenderToolkit_scripts/xrommimport.py
+++ b/XrommBlenderToolkit_scripts/xrommimport.py
@@ -11,14 +11,13 @@ import csv
 import numpy as np
 from mathutils import Matrix, Vector
 
-#file name: hardcoded for now
-#importCSV = "C:\\Users\\pfalk\\OneDrive\\WORK\\CurrentWork\\MyBlenderStuff\\XROMM ToolKit for Blender\\Sample Data\\RigidBody001_Upper_transformation.csv"
 
 
-
-def importRBT(importCSV):
+def importRBT(importCSV, skipFirstColumn):
     #hardcode datatype for now
-
+    ### Inputs:
+    # importCSV (absolute path to the target csv file, string)
+    # skipFirstColumn (boolean, whether or not to skip the first column of the CSV when importing)
     #############################
     #Rigid Body Transformation
     #############################
@@ -30,10 +29,16 @@ def importRBT(importCSV):
     with open(importCSV, newline='') as csvfile:
         reader = csv.reader(csvfile, delimiter=',', quotechar='"')
         next(reader)
+
+        
         # Loop through each row in the CSV file
         for row in reader:
-            # Extract the 16 elements of the matrix from the row
-            matrix_elements = [float(x) for x in row[:16]]
+            
+            if skipFirstColumn: # If we skip the first column, extract element 1-16
+                matrix_elements = [float(x) for x in row[1:17]]
+            else: #else, we extract element 0-15 as normal. 
+                matrix_elements = [float(x) for x in row[:16]]
+            
             print("Me: ", matrix_elements)
             # Create a 4x4 matrix from the elements
             matrix = Matrix((


### PR DESCRIPTION
Hi Peter,
Karl sent me some XROMM data for a project we're working on. Since I am allergic to Maya, I wanted to use your Blender plugin for this. Thanks a lot for making it, it works very well.

I got an import error when trying to import the rigid body transformations. This is because Karl's CSV data has the frame numbers in the first column, and in the workflow description he sent me, he told me to tick the "Row headers in column 1" option during import. Because this button doesn't exist in your version of the plugin, the plugin imported the data entries in the CSV file.

Because we will be analyzing several trials, I decided to make the necessary modifications to your plugin, by forking it and adding a "Skip first data column" button, and making the necessary changes to importRBT. The changes work for the dataset I'm analyzing, so I've opened this pull request, since I think the option could be a useful feature in your plugin. I've tried to follow your coding style when making my changes.

I have also taken the liberty to flip one of the descriptions and labels in one of the buttons to what I think you intended, and modified some of the comments, and added an "undo" flag in the bl_options which hopefully addresses one of the issues you encountered (although I didn't encounter it myself). 

I also added a tiny quality of life emprovement (the playback window now automatically sets the end frame based on the number of keyframes that are imported).

I considered going through transrotimport as well, to see if those could benefit from a "skip first column" button as well, but I don't understand the intended use of those functions, so I opted not to. I also didn't change the readme, pending your approval, although I think the option is self-explanatory so may not need a modification to the readme.


Best,
Pasha